### PR TITLE
🐛 about, not found Page 404 error 수정

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
+PUBLIC_URL = https://bono-log.github.io/
 GENERATE_SOURCEMAP=false

--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-PUBLIC_URL = https://bono-log.github.io/
+PUBLIC_URL = https://bono-log.github.io
 GENERATE_SOURCEMAP=false

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ function App() {
         <PageHeader />
         <Routes>
           <Route path="/" element={<Home />} />
-          <Route path="about/" element={<About />} />
+          <Route path="/about" element={<About />} />
           <Route path="post/:id" element={<PageDetail />} />
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ function App() {
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/about" element={<About />} />
-          <Route path="post/:id" element={<PageDetail />} />
+          <Route path="/post/:id" element={<PageDetail />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
         <PageFooter />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import './App.css';
 function App() {
   return (
     <div className="page-wrapper">
-      <BrowserRouter>
+      <BrowserRouter basename={process.env.PUBLIC_URL}>
         <PageHeader />
         <Routes>
           <Route path="/" element={<Home />} />


### PR DESCRIPTION
## summary

build, gh-pages 배포 시 about, not found Page가 404 error로 정상 출력되지 않는 현상 수정하였습니다.

- Resolves: #83 

## PR 유형

어떤 유형인가요? 해당되는 유형에 체크해주세요.

**PR 제목 작성시 '[유형에 맞는 gitmoji] 제목'으로 입력 부탁드립니다.**

- [ ] ✨ Feature / 새로운 기능
- [x] 🐛 Fix / 버그 수정
- [ ] 💄 Style / CSS 등 사용자 UI 디자인 변경
- [ ] ♻️ Refactor / 코드 리팩토링(구조 개선, 디렉토리 변경 등...)
- [ ] 📝 Docs / 문서 수정
- [ ] ✅ Test / 테스트 추가, 테스트 리팩토링
- [ ] 💬 Chore / 그 외, 모든 변경점(Package, Rename, Remove, etc...)

## 변경 사항

환경변수로 public_url 설정을 해주었습니다.

gh-pages와 같은 경우 SPA를 지원하지 않는다고 합니다.
라우팅 처리 로직이 React 내부에서 처리되고, 응답으로 index.html만 반환하기 때문입니다.

따라서, ``/about``이나 ``/*``(not-found) page들은 정적 경로이므로 명시적으로 라우팅을 해주지 않아 404 error가 뜬 것으로 추측됩니다.
``/post/:id``는 경로에 포함된 파라미터 값에 따라 동적으로 컴포넌트를 렌더링하기 때문에 배포 시 정상적으로 출력된 것으로 보입니다.

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 정상 동작 확인 여부
- [x] commit message convention 충족 여부
